### PR TITLE
dietlibc support, upstart support

### DIFF
--- a/runit.spec
+++ b/runit.spec
@@ -8,7 +8,7 @@
 
 Name:           runit
 Version:        2.1.1
-Release:        4
+Release:        4%{?_with_dietlibc:diet}
 
 Group:          System/Base
 License:        BSD


### PR DESCRIPTION
Hi,

I've made a few changes to the spec file to support upstart, and building against dietlibc.

It's not perfect - I will probably be changing it to add runsvdir.conf as a file rather than creating it in the post-install script. Also, I want to add support for systemd too (used on Fedora).

I'll send further updates when I get round to that

R.
