### PR TITLE
Fix build.sh to work on Amazon Linux.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,8 @@
 
 whereami=$(dirname $0)
 
-if [ ! -f "/etc/rpm/macros.dist" ];      then echo "please install 'buildsys-macros' rpm and try again" ; exit 1 ; fi
+if [ ! -f "/etc/rpm/macros.dist" ] && \
+   [ ! -f "/etc/rpm/macros.disttag" ];   then echo "please install 'buildsys-macros' rpm and try again" ; exit 1 ; fi
 if [ ! -f "$(which rpmbuild)" ];         then echo "please install 'rpm-build' rpm and try again" ; exit 1 ; fi
 if [ ! -f "$(which spectool)" ];         then echo "please install 'rpmdevtools' rpm and try again" ; exit 1 ; fi
 if [ ! -f "$(which rpmdev-setuptree)" ]; then echo "please install 'rpmdevtools' rpm and try again" ; exit 1 ; fi


### PR DESCRIPTION
On Amazon Linux, `buildsys-macros` providing `/etc/rpm/macros.dist` does
not exist. Rather, `system-release` provides `/etc/rpm/macros.disttag`.
Apart from failing the check for `/etc/rpm/macros.dist` in build.sh, the
RPM builds fine. This patch changes build.sh to look for either file.

I ran into this while using [Opscode's runit cookbook](https://github.com/opscode-cookbooks/runit), which now bundles runit-rpm and uses it to build runit on RHEL-family platforms.
