### PR TITLE
Fix missing macro on rhel7

### DIFF
--- a/runit.spec
+++ b/runit.spec
@@ -32,6 +32,9 @@ BuildRequires: make gcc
 %if 0%{?rhel} >= 6
 BuildRequires:  glibc-static
 %endif
+%if 0%{?rhel} >= 7
+BuildRequires: systemd-units
+%endif
 
 %{?_with_dietlibc:BuildRequires:        dietlibc}
 


### PR DESCRIPTION
According Fedora systemd guidelines https://fedoraproject.org/wiki/Packaging:Systemd?rd=Packaging:Guidelines:Systemd package must have `BuildRequires: systemd-units` to have `{_unitdir}` macro.