### PR TITLE
Improve systemd service file

### DIFF
--- a/runsvdir-start.service
+++ b/runsvdir-start.service
@@ -4,6 +4,7 @@ Description=Runit Process Supervisor
 [Service]
 ExecStart=/usr/sbin/runsvdir-start
 Restart=always
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
runsvdir service file: Let runit manage / kill subprocesses by specifying KillMode. When systemd wants to shutdown runit, it should kill the runsvdir process only, and let runsvdir kill the children.
