### PR TITLE
Allow the user to have a preexisting %_topdir

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,12 +8,16 @@ if [ ! -f "$(which rpmbuild)" ];         then echo "please install 'rpm-build' r
 if [ ! -f "$(which spectool)" ];         then echo "please install 'rpmdevtools' rpm and try again" ; exit 1 ; fi
 if [ ! -f "$(which rpmdev-setuptree)" ]; then echo "please install 'rpmdevtools' rpm and try again" ; exit 1 ; fi
 
-# creates ~/rpmbuild
+# Might create ~/rpmbuild, or it might use an existing build %{_topdir}
+# named in ~/.rpmmacros
 /usr/bin/rpmdev-setuptree
 
-cp -f ${whereami}/runit.spec ~/rpmbuild/SPECS/
-cp -f ${whereami}/*.patch    ~/rpmbuild/SOURCES/
-cp -f ${whereami}/runsvdir-start.service    ~/rpmbuild/SOURCES/
-/usr/bin/spectool -C ~/rpmbuild/SOURCES/ -g ${whereami}/runit.spec 
+SPECS=$(rpm --eval "%{_specdir}")
+SOURCES=$(rpm --eval "%{_sourcedir}")
+cp -f "${whereami}/runit.spec" "$SPECS"
+cp -f "${whereami}"/*.patch    "$SOURCES"
+cp -f "${whereami}/runsvdir-start.service"    "$SOURCES"
+/usr/bin/spectool -C "$SOURCES" -g "${whereami}/runit.spec "
 
-rpmbuild -bb ~/rpmbuild/SPECS/runit.spec
+PATH=/usr/bin:/bin
+rpmbuild -bb "$SPECS/runit.spec"


### PR DESCRIPTION
I had a pre-existing ~/.rpmmacros and a pre-existing %{_topdir}.  These patches allowed me to use build.sh.

The patch also explicitly sets PATH before  calling rpmbuild, so that the rpmbuild always uses standard binaries.